### PR TITLE
feat(docker): add Dockerfile to support convenient Jekyll development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
-FROM ubuntu:latest
+FROM ruby:3.2
 
-RUN apt update && apt install -y curl git build-essential libssl-dev libreadline-dev zlib1g-dev ruby-full vim 
-RUN gem install jekyll bundler
-RUN echo "echo 'set your proxy and clone the repository `https://github.com/hust-open-atom-club/OpenAtomClub.git` or `https://github.com/<your-name>/OpenAtomClub.git` '">> ~/.bashrc
+WORKDIR /app
 
-WORKDIR /workspace
+# RUN apk add --no-cache bash build-base git 
+
+
+
+COPY . .
+# NOTE: you need to set a proxy to run this command
+# RUN bundle install --path=~/vendor/bundler
+
+
 
 EXPOSE 4000
-CMD ["bash"]
+CMD bash/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:latest
+
+RUN apt update && apt install -y curl git build-essential libssl-dev libreadline-dev zlib1g-dev ruby-full vim 
+RUN gem install jekyll bundler
+RUN echo "echo 'set your proxy and clone the repository `https://github.com/hust-open-atom-club/OpenAtomClub.git` or `https://github.com/<your-name>/OpenAtomClub.git` '">> ~/.bashrc
+
+WORKDIR /workspace
+
+EXPOSE 4000
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -22,3 +22,26 @@
    在命令行末尾添加 `--profile` 可以查看编译性能分析（每个源文件耗时），添加 `--trace` 可以在出错时输出 stack trace
 
    正式部署时需要添加环境变量 `JEKYLL_ENV=production`，详情请见 GitHub Actions 的 workflow 配置
+
+## 使用docker环境开发
+
+1. 构建
+ 
+```
+docker build -t <docker-name> .
+```
+
+2. 运行
+
+
+```
+docker run -name <docker-name>
+```
+
+3. 开发
+
+- 需要配置代理,方法多样，详见[https://docs.docker.com/engine/cli/proxy/]
+
+- 在宿主机中查看网页
+
+运行容器后，Jekyll 服务会启动。在宿主机的浏览器中访问 `http://localhost:<port>` ,你将看到 Jekyll 生成的网页, 端口默认为4000,请确定该端口空闲。

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ docker build -t <docker-name> .
 
 
 ```
-docker run -name <docker-name>
+docker run -it --name <docker-name> /bin/bash
 ```
 
 3. 开发


### PR DESCRIPTION
## 内容
- 添加基于 ruby的 Dockerfile
- 更新 README , 包含 Docker 使用说明

## 目的
- 提供一个便捷的 Docker 开发环境，避免本地环境配置问题。

## test pass
1. 运行 `docker-compose up`，确认 Jekyll 服务器正常启动。
2. 访问 `http://localhost:4000`，确认网站正常显示。