### PR TITLE
fix(ci): update set-ruby version

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Ruby
-        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        uses: ruby/setup-ruby@v1.221.0
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
update set-ruby from 1.161 to 1.221 to fix ci failed
https://github.com/ruby/setup-ruby/issues/595

tested in my repo
![image](https://github.com/user-attachments/assets/caea7fbd-daaf-49a4-84fc-a08e18dc985e)
