### PR TITLE
docs: move badges from .github/profile/README.md to root README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+
+<img src="https://github.com/hust-open-atom-club/.github/blob/main/profile/assets/header.png" style="width:60%">
+
+<h3><a href="https://hust.openatom.club">hust.openatom.club</a></h3>
+
+
+<!-- 参考：https://shields.io/badges/static-badge -->
+<!-- [![](https://dcbadge.limes.#FB7299/api/server/EMJqcQCCpW)](https://discord.gg/EMJqcQCCpW) -->
+[![](https://img.shields.io/badge/Join_QQ-HUST_OPEN_ATOM_CLUB_|_OS2EDU-white?style=for-the-badge&color=76bad9&logo=qq&logoColor=76bad9)](https://qm.qq.com/q/2uEd11lkWk)
+[![](https://img.shields.io/badge/Join_Discord-HUST_OPEN_ATOM_CLUB-white?style=for-the-badge&color=5662f6&logo=discord&logoColor=5662f6)](https://discord.gg/EMJqcQCCpW)
+[![](https://img.shields.io/badge/Visit_Bilibili-%E5%8D%8E%E7%A7%91%E5%BC%80%E6%94%BE%E5%8E%9F%E5%AD%90%E4%BF%B1%E4%B9%90%E9%83%A8-white?style=for-the-badge&color=FB7299&logo=bilibili&logoColor=FB7299)](https://space.bilibili.com/3537107102468877)
+[![](https://img.shields.io/badge/%E5%85%AC%E4%BC%97%E5%8F%B7-%E5%BC%80%E6%BA%90%E5%86%85%E6%A0%B8%E5%AE%89%E5%85%A8%E4%BF%AE%E7%82%BC-white?style=for-the-badge&color=06cb64E&logo=wechat&logoColor=06cb64)](https://mp.weixin.qq.com/s/5BRqbmsE9lfhai7mjt1gRQ)
+
+
+<h1>华科开放原子开源俱乐部</h1>
+
+
+
+</div>
 这属于华中科技大学开放原子开源俱乐部的官网页面。
 
 ## 添加与修改页面


### PR DESCRIPTION
This commit migrates the status and build badges from .github/profile/README.md to the root README.md so that they are visible on the project’s main page by default.

Related: hust-open-atom-club/OpenAtomClub#62
See: https://github.com/hust-open-atom-club/OpenAtomClub/issues/62